### PR TITLE
Added safety check when accessing cleaned_data

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -356,7 +356,8 @@ class BaseForm:
                 else:
                     self._errors[field] = self.error_class()
             self._errors[field].extend(error_list)
-            if field in self.cleaned_data:
+            # Cleaning only neccesary if cleaned_data exists
+            if self.cleaned_data is not None and field in self.cleaned_data:
                 del self.cleaned_data[field]
 
     def has_error(self, field, code=None):


### PR DESCRIPTION
Adding form errors requires that cleaned data is removed from the form. However this fails when the cleaned data doesn't exist, for example if you inject an error before rendering the form for the first time.